### PR TITLE
Generate less HTML pages

### DIFF
--- a/src/o2wRepository.mli
+++ b/src/o2wRepository.mli
@@ -20,7 +20,7 @@ open O2wTypes
 
 (** Create a list of package pages to generate for a repository *)
 val to_pages: href_prefix:string -> statistics:statistics_set option ->
-  repository_info -> page list
+  preds:pred list list -> repository_info -> page list
 
 (** Generate the list of HTML links for a list of page names *)
 val sortby_links:

--- a/src/opam2web.ml
+++ b/src/opam2web.ml
@@ -58,7 +58,7 @@ let make_website user_options repo_info =
   let content_dir = user_options.content_dir in
   let preds = user_options.preds in
   Printf.printf "++ Building the package pages.\n%!";
-  let pages = O2wRepository.to_pages ~href_prefix ~statistics repo_info in
+  let pages = O2wRepository.to_pages ~href_prefix ~statistics ~preds repo_info in
   Printf.printf "++ Building the documentation pages.\n%!";
   let menu_of_doc = O2wDocumentation.to_menu ~content_dir in
   let criteria = ["name"; "popularity"; "date"] in


### PR DESCRIPTION
A quick & dirty hack to generate only the HTML pages of packages satisfying
--where
