### PR TITLE
Switch to latest cow/omd

### DIFF
--- a/ext/css/site.css
+++ b/ext/css/site.css
@@ -196,3 +196,13 @@ tr.embedded-formula > td:last-child {
   width: 100%;
   text-align: right;
 }
+
+
+h2 {
+  border-bottom: 1px solid lightgrey;
+  padding-top: 5px;
+}
+
+h2, h3, h4 {
+  margin-top: 1ex;
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ WWWDIR ?= www
 BUILD=_build
 
 OCAMLBUILD=ocamlbuild -classic-display
-PACKAGES=-pkgs cow,cow.syntax,opam-lib.client,opamfu.cli,cmdliner
+PACKAGES=-pkgs omd,cow,cow.syntax,opam-lib.client,opamfu.cli,cmdliner
 SYNTAX=-tags "syntax(camlp4o)"
 FLAGS=-use-ocamlfind -cflags "-bin-annot" -no-links -tags "debug"
 INCLUDES=-I apalog

--- a/src/o2wDocumentation.ml
+++ b/src/o2wDocumentation.ml
@@ -48,23 +48,6 @@ let split_filename (file: string): (string * string) =
    directory *)
 let to_menu ~content_dir ~pages =
 
-  let wrap_li ~depth c = <:html<<li>$c$</li>&>> in
-
-  let wrap_a ~depth ~heading c =
-    let href = "#" ^ Cow.Markdown.id_of_heading heading in
-    let html_a =
-      if depth > 1 then <:html<<a href="$str: href$"><small>$c$</small></a>&>>
-      else <:html<<a href="$str: href$"><strong>$c$</strong></a>&>>
-    in wrap_li ~depth html_a
-  in
-
-  let wrap_ul ~depth l =
-    if depth = 0 then
-      <:html<<ul class="nav nav-list bs-docs-sidenav">$l$</ul>&>>
-    else
-      <:html<$l$&>>
-  in
-
   (* Convert a content page to html *)
   let to_html doc_menu kind filename: Cow.Html.t =
     if not (OpamFilename.exists filename) then (
@@ -75,11 +58,9 @@ let to_menu ~content_dir ~pages =
       match kind with
       | "html" -> Cow.Html.of_string content
       | "md" ->
-        let md_content = Cow.Markdown_github.of_string content in
-        let html_toc =
-          Cow.Markdown.to_html_toc
-            ~wrap_list:wrap_ul ~wrap_item:wrap_a md_content
-        in
+        let md_content = Omd.of_string content in
+        let md_toc = Omd.toc md_content in
+        let html_toc = Cow.Html.of_string (Omd.to_html md_toc) in
         <:html<
           <div class="row">
             <div class="span3">
@@ -92,7 +73,7 @@ let to_menu ~content_dir ~pages =
           </div>
           </div>
           <div class="span9">
-          $Cow.Markdown.to_html md_content$
+          $Cow.Html.of_string (Omd.to_html md_content)$
           </div>
         </div>
       >>

--- a/src/o2wPackage.ml
+++ b/src/o2wPackage.ml
@@ -45,7 +45,7 @@ let compare_date ?(reverse = false) pkg_dates p1 p2 =
 
 (* An HTML fragment for the description of a package *)
 let html_descr (short,long) =
-  let to_html md = Cow.Markdown.to_html (Cow.Markdown_github.of_string md) in
+  let to_html md = Cow.Markdown.of_string md in
   begin <:html<
     <h4>$str:short$</h4>
     $to_html long$

--- a/src/opam2web.ml
+++ b/src/opam2web.ml
@@ -92,8 +92,7 @@ let make_website user_options universe =
     try
       let filename = OpamFilename.of_string filename in
       let contents = OpamFilename.read filename in
-      let contents = Cow.Markdown_github.of_string contents in
-      let contents = Cow.Markdown.to_html contents in
+      let contents = Cow.Markdown.of_string contents in
       <:html<
         <div class="container">
         $contents$


### PR DESCRIPTION
There is a small regression on the formatting of the TOC for doc pages though
(used to be rewritten to use the proper `<ul>` bootstrap classes)
