### PR TITLE
CSS: Hide docs menu that was getting mixed up on smaller devices

### DIFF
--- a/ext/css/site.css
+++ b/ext/css/site.css
@@ -1,5 +1,5 @@
 body {
-  padding-top: 60px;
+  /* padding-top: 60px; */
   padding-bottom: 40px;
 }
 

--- a/src/o2wBlog.ml
+++ b/src/o2wBlog.ml
@@ -215,7 +215,7 @@ let make_pages entries =
         <div class="row">
           <div class="span3">
             <span> </span>
-            <div class="bs-docs-menu" data-spy="affix"
+            <div class="bs-docs-menu hidden-phone" data-spy="affix"
                  data-offset-top="0" data-offset-bottom="140">
               $nav_menu entry$
             </div>

--- a/src/o2wDocumentation.ml
+++ b/src/o2wDocumentation.ml
@@ -65,7 +65,7 @@ let to_menu ~content_dir ~pages =
           <div class="row">
             <div class="span3">
           <span> </span>
-          <div class="bs-docs-menu"
+          <div class="bs-docs-menu hidden-phone"
               data-spy="affix"
               data-offset-top="0" data-offset-bottom="140">
             $doc_menu$


### PR DESCRIPTION
should make the site OK on phones.
