### PR TITLE
pkg-latest: add version independent package pages

### DIFF
--- a/src/o2wUniverse.mli
+++ b/src/o2wUniverse.mli
@@ -20,7 +20,7 @@ open OpamTypes
 open O2wTypes
 
 (** Create a list of package pages to generate for a repository *)
-val to_pages: statistics:statistics_set option ->
+val to_pages: statistics:statistics_set option -> prefix:string ->
   Cow.Html.t OpamfUniverse.t -> page list
 
 (** Generate the list of HTML links for a list of page names *)

--- a/src/opam2web.ml
+++ b/src/opam2web.ml
@@ -52,7 +52,9 @@ let make_website user_options universe =
   let statistics = O2wStatistics.statistics_set user_options.logfiles in
   let content_dir = user_options.content_dir in
   Printf.printf "++ Building the package pages.\n%!";
-  let pages = O2wUniverse.to_pages ~statistics universe in
+  let pages = O2wUniverse.to_pages
+    ~statistics ~prefix:packages_prefix universe
+  in
   Printf.printf "++ Building the documentation pages.\n%!";
   let menu_of_doc () = O2wDocumentation.to_menu ~content_dir in
   Printf.printf "++ Building the blog.\n%!";


### PR DESCRIPTION
This page simply reproduces the content of the latest package version, which is the approach our brethren take over at [hackage][0].

[0]: http://hackage.haskell.org/

Closes ocaml/opam2web#69
Invalidates ocaml/opam2web#117