### PR TITLE
Stats count only leaf pkg

### DIFF
--- a/src/o2wStatistics.mli
+++ b/src/o2wStatistics.mli
@@ -20,7 +20,7 @@ open OpamTypes
 open O2wTypes
 
 (** Generate statistics on log entries *)
-val statistics_set: filename list -> statistics_set option
+val statistics_set: filename list -> dirname list -> statistics_set option
 
 (** Return the top packages *)
 val top_packages: ?ntop:int -> ?reverse:bool -> (package -> 'a) ->

--- a/src/o2wUniverse.mli
+++ b/src/o2wUniverse.mli
@@ -41,6 +41,8 @@ val to_html:
 
 val latest_version_packages: 'a OpamStateTypes.switch_state -> package_set
 
+val load_opam_state : dirname list -> OpamStateTypes.unlocked OpamStateTypes.switch_state
+
 val load: statistics_set option -> dirname list -> univ
 
 (*

--- a/src/opam2web.ml
+++ b/src/opam2web.ml
@@ -52,7 +52,9 @@ let include_files (path: string) files_path : unit =
 let make_website user_options =
   Printf.printf "++ Building the new stats from %s.\n%!"
     (OpamStd.List.to_string OpamFilename.prettify user_options.logfiles);
-  let statistics = O2wStatistics.statistics_set user_options.logfiles in
+  let statistics = O2wStatistics.statistics_set user_options.logfiles
+      (List.map OpamFilename.Dir.of_string user_options.repositories)
+  in
   let content_dir = user_options.content_dir in
   let universe =
     O2wUniverse.load statistics


### PR DESCRIPTION
This PR concerns package statistics calculation: if a user download several packages in the same time*, only leaf package are kept for count.
(*) same time = consecutive download timestamps < given period.