### PR TITLE
Fixes, opam2 & more accurate stats

### DIFF
--- a/src/o2wHome.ml
+++ b/src/o2wHome.ml
@@ -74,7 +74,6 @@ let to_html ~content_dir ~statistics ~news univ =
       let popularity_fn pkg =
         try OpamPackage.Name.Map.find pkg.name sset
         with Not_found -> 0L in
-      let packages = univ.st.packages in
       let nb_packages = OpamPackage.Set.cardinal latest_packages in
       let top10_pkgs = O2wStatistics.top_packages ~ntop: 10 popularity_fn latest_packages in
       let top10_items = List.map mk_top_li top10_pkgs in

--- a/src/o2wStatistics.ml
+++ b/src/o2wStatistics.ml
@@ -268,10 +268,12 @@ let compute_stats ?(unique=false) mcache repos =
     let get_dependencies_set adjacent env =
       let module OPS = OpamPackage.Name.Set in
       FloM.fold (fun _ p (env, deps) ->
-          let n_env, ldeps = List.fold_left
+          let n_env, ldeps =
+            List.fold_left
               (fun (acc_env, acc_d) pi ->
                  let e,d = get_package_deps acc_env pi in
-                 e,d::acc_d) (env,[]) p in
+                 e,d::acc_d) (env,[]) p
+          in
           n_env, OPS.union deps (OPS.of_list (List.flatten ldeps)))
         adjacent (env, OPS.empty)
     in

--- a/src/o2wStatistics.ml
+++ b/src/o2wStatistics.ml
@@ -445,7 +445,7 @@ type cache_elt = {
 }
 type cache = cache_elt OpamFilename.Map.t
 let cache_file = OpamFilename.of_string "~/.cache/opam2web2/stats_cache"
-let cache_format_version = 2
+let cache_format_version = 3
 let version_id =
   Digest.string (OpamVersion.(to_string (full ())) ^" "^
                  string_of_int cache_format_version)

--- a/src/o2wStatistics.ml
+++ b/src/o2wStatistics.ml
@@ -31,6 +31,21 @@ let empty_stats_set = {
   month_leaf_pkg_stats = OpamPackage.Map.empty;
 }
 
+let string_of_stats s =
+  OpamStd.List.to_string Int64.to_string
+    [ Int64.of_int (OpamPackage.Map.cardinal s.pkg_stats) ;
+      s.global_stats ;
+      s.update_stats;
+      s.users_stats ]
+
+let string_of_stats_set stats =
+  Printf.sprintf
+    "all_time: %s\nday: %s\nweek: %s\nmonth: %s\n"
+    (string_of_stats stats.alltime_stats)
+    (string_of_stats stats.day_stats)
+    (string_of_stats stats.week_stats)
+    (string_of_stats stats.month_stats)
+
 let timestamp_regexp =
   Re.Str.regexp "\\([0-9]+\\)/\\([A-Z][a-z]+\\)/\\([0-9]+\\):\\([0-9]+\\):\
                  \\([0-9]+\\):\\([0-9]+\\) [-+][0-9]+"

--- a/src/o2wStatistics.ml
+++ b/src/o2wStatistics.ml
@@ -312,7 +312,7 @@ let compute_stats ?(unique=false) mcache st =
         match lst with
         | [] -> max
         | (next, _)::rest ->
-          if next -. max < five_min then
+          if next -. max < two_min then
             aux next rest
           else max
       in

--- a/src/o2wTypes.mli
+++ b/src/o2wTypes.mli
@@ -66,10 +66,11 @@ type statistics = {
 }
 
 type statistics_set = {
-  alltime_stats: statistics;
-  day_stats    : statistics;
-  week_stats   : statistics;
-  month_stats  : statistics;
+  alltime_stats        : statistics;
+  day_stats            : statistics;
+  week_stats           : statistics;
+  month_stats          : statistics;
+  month_leaf_pkg_stats : int64 package_map;
 }
 
 (** Log entry intermediate types *)

--- a/src/o2wTypes.mli
+++ b/src/o2wTypes.mli
@@ -20,7 +20,7 @@ type univ = {
   st: OpamStateTypes.unlocked OpamStateTypes.switch_state;
   dates: float package_map;
   name_popularity: int64 name_map option;
-  version_popularity: int64 package_map option;
+  version_popularity: (int64 package_map * (package * package_set) OpamStd.String.Map.t) option;
   depends: package_set package_map;
   rev_depends: package_set package_map;
   depopts: package_set package_map;
@@ -71,6 +71,7 @@ type statistics_set = {
   week_stats           : statistics;
   month_stats          : statistics;
   month_leaf_pkg_stats : int64 package_map;
+  hash_pkgs_map        : (package * package_set) OpamStd.String.Map.t;
 }
 
 (** Log entry intermediate types *)

--- a/src/o2wUniverse.ml
+++ b/src/o2wUniverse.ml
@@ -232,7 +232,7 @@ let load statistics repo_roots =
     match statistics with
     | None -> None, None
     | Some s ->
-      let vp = s.month_stats.pkg_stats in
+      let vp = s.month_leaf_pkg_stats in
       let np =
         OpamPackage.Map.fold (fun nv x ->
             OpamPackage.Name.Map.update nv.name (Int64.add x) 0L)

--- a/src/o2wUniverse.ml
+++ b/src/o2wUniverse.ml
@@ -232,11 +232,11 @@ let load statistics repo_roots =
     match statistics with
     | None -> None, None
     | Some s ->
-      let vp = s.month_leaf_pkg_stats in
+      let vp = s.month_stats.pkg_stats in
       let np =
         OpamPackage.Map.fold (fun nv x ->
             OpamPackage.Name.Map.update nv.name (Int64.add x) 0L)
-          vp OpamPackage.Name.Map.empty
+          s.month_leaf_pkg_stats OpamPackage.Name.Map.empty
       in
       Some vp, Some np
   in

--- a/src/o2wUniverse.ml
+++ b/src/o2wUniverse.ml
@@ -232,7 +232,7 @@ let load statistics repo_roots =
     match statistics with
     | None -> None, None
     | Some s ->
-      let vp = s.month_stats.pkg_stats in
+      let vp = s.month_stats.pkg_stats, s.hash_pkgs_map in
       let np =
         OpamPackage.Map.fold (fun nv x ->
             OpamPackage.Name.Map.update nv.name (Int64.add x) 0L)


### PR DESCRIPTION
- Don't store occurrence for user map (transformed into set)
- Remove dependencies only from popularity stats
- Include opam2.0 packages in stats
- Share dl stats for packages having same md5
- Dead window decreased to **two** minutes
