### PR TITLE
Catch LexCombinedLog.Scanner_error

### DIFF
--- a/src/o2wStatistics.ml
+++ b/src/o2wStatistics.ml
@@ -561,11 +561,15 @@ let statistics_set files repos =
       let percent = if l.size = 0 then 100 else 100 * l.reads / l.size in
       Printf.printf "\rReading new entries from %s: %3d%%%!" l.name percent;
       let mcache =
-        List.fold_left
-          (fun mcache line ->
-             try add_mcache_entry mcache (mk_entry hash_map line)
-             with Ghost_package -> mcache)
-          mcache (Readcombinedlog.read l chunk_size)
+        try
+          List.fold_left
+            (fun mcache line ->
+               try add_mcache_entry mcache (mk_entry hash_map line)
+               with Ghost_package -> mcache)
+            mcache (Readcombinedlog.read l chunk_size)
+        with Lexcombinedlog.Scanner_error ->
+        (Printf.eprintf "Scanner error, dropping a chunk from %s\n" l.name;
+         mcache)
       in
       if Readcombinedlog.is_empty l then
         (Printf.printf "\rReading new entries from %s: %3d%%\n%!" l.name 100;


### PR DESCRIPTION
Temporary fix of
```
Reading logs cache from /home/opam/.cache/opam2web2/stats_cache... done.
/home/opam/var/log/access.log: cache found (5017 out of 2106750 KB new)

Reading new entries from /home/opam/var/log/access.log:   0%wrong date: -
opam2web: internal error, uncaught exception:
          Lexcombinedlog.Scanner_error
          Raised at file "src/apalog/lexcombinedlog.mll", line 42, characters 91-110
          Called from file "src/apalog/lexcombinedlog.ml" (inlined), line 366, characters 4-34
          Called from file "src/apalog/readcombinedlog.ml", line 58, characters 21-47
          Called from file "src/o2wStatistics.ml", line 568, characters 17-52
          Called from file "src/o2wStatistics.ml", line 578, characters 23-49
          Called from file "list.ml", line 88, characters 24-34
          Called from file "src/o2wStatistics.ml", line 577, characters 6-628
          Called from file "src/opam2web.ml", line 55, characters 19-139
          Called from file "src/cmdliner_term.ml", line 27, characters 19-24
          Called from file "src/cmdliner.ml", line 106, characters 32-39
```