### PR TITLE
packages: catch `Cow.Markdown.of_string` parsing error

### DIFF
--- a/src/o2wPackage.ml
+++ b/src/o2wPackage.ml
@@ -204,7 +204,7 @@ let to_html ~prefix univ pkg =
       | None -> Html.empty
       | Some md ->
         try Cow.Markdown.of_string md
-        with Invalid_argument _ ->
+        with Invalid_argument _ | Parsing.Parse_error->
           OpamConsole.error "BAD MARKDOWN in %s descr"
             (OpamPackage.to_string pkg);
           Html.string md


### PR DESCRIPTION
Fixes & noticed in https://github.com/ocaml/opam-repository/issues/13962