### PR TITLE
Add links to the API documentation and man-pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ ARG OPAM_GIT_SHA=master
 RUN echo ${OPAM_REPO_GIT_SHA} >> /www/opam_git_sha
 RUN echo ${BLOG_GIT_SHA} >> /www/blog_git_sha
 RUN echo ${OPAM_GIT_SHA} >> /www/doc_git_sha
+RUN mkdir -p /www/doc
+RUN cp -r /usr/local/share/opam2web/content/doc/api /www/doc/api
+RUN cp -r /usr/local/share/opam2web/content/doc/man /www/doc/man
 RUN /usr/local/bin/opam-web.sh ${DOMAIN} ${OPAM_REPO_GIT_SHA} ${BLOG_GIT_SHA}
 WORKDIR /srv
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/src/o2wDocumentation.ml
+++ b/src/o2wDocumentation.ml
@@ -282,4 +282,20 @@ let to_menu ~content_dir =
       match srcurl_12 with
       | None -> None
       | Some u -> Some (u ^ "/index.menu");
+  };
+  {
+    menu_source = "api";
+    menu_link = Uri.make ~path:"doc/api/" ();
+    menu_link_text = "API";
+    menu_link_html = Html.string "API";
+    menu_item = External;
+    menu_srcurl = None;
+  };
+  {
+    menu_source = "man";
+    menu_link = Uri.make ~path:"doc/man/" ();
+    menu_link_text = "Man pages";
+    menu_link_html = Html.string "Man pages";
+    menu_item = External;
+    menu_srcurl = None;
   }]


### PR DESCRIPTION
Related to https://github.com/ocaml/opam/issues/6637

Previously these directories were only partially filled as only the files linked elsewhere in the website were copied over from the `/usr/local/share/opam2web/content` directory.

The opam2web menu API can work in two ways based on whether `menu_item` is `External` or `Internal`/`Submenu`.
* In External mode nothing is copied over, only files mentioned elsewhere in one of the parsed markdown files are
* In Internal mode one has to give a link to the main index file (content of a html file, not full html) which links the files to copy over
* The Submenu mode is similar to Internal the whole list of links will be part of the menu itself

Published in staging.opam.ocaml.org