### PR TITLE
lowercase opam where appropriate

### DIFF
--- a/src/o2wDocumentation.ml
+++ b/src/o2wDocumentation.ml
@@ -264,8 +264,8 @@ let to_menu ~content_dir =
   [{
     menu_source = "1.1";
     menu_link = Uri.make ~path:("doc/1.1/") ();
-    menu_link_text = "Archives (OPAM 1.1)";
-    menu_link_html = Html.string "Archives (OPAM 1.1)";
+    menu_link_text = "Archives (opam 1.1)";
+    menu_link_html = Html.string "Archives (opam 1.1)";
     menu_item = External;
     menu_srcurl =
       match srcurl_11 with
@@ -275,8 +275,8 @@ let to_menu ~content_dir =
   {
     menu_source = "1.2";
     menu_link = Uri.make ~path:("doc/1.2/") ();
-    menu_link_text = "Archives (OPAM 1.2)";
-    menu_link_html = Html.string "Archives (OPAM 1.2)";
+    menu_link_text = "Archives (opam 1.2)";
+    menu_link_html = Html.string "Archives (opam 1.2)";
     menu_item = External;
     menu_srcurl =
       match srcurl_12 with


### PR DESCRIPTION
the only letfover OPAM are not in code (OpamFile.OPAM), and in the submodule pointing to the ocaml/opam wiki -- which I can change as well if you like (it is here content/doc). Since I don't know of how to PR to wikis, please fine attached a patch for the wiki, feel free to review and push.

[wiki.diff.patch](https://github.com/user-attachments/files/24644189/wiki.diff.patch)


